### PR TITLE
drivers: block: add NULL as 'groups' argument to device_add_disk

### DIFF
--- a/drivers/block/vs_block_client.c
+++ b/drivers/block/vs_block_client.c
@@ -550,7 +550,7 @@ static int vs_block_client_disk_add(struct block_client *client)
 	client->blkdev = blkdev;
 	vs_service_state_unlock(client->service);
 
-	device_add_disk(&client->service->dev, blkdev->disk);
+	device_add_disk(&client->service->dev, blkdev->disk, NULL);
 	dev_dbg(&client->service->dev, "added block disk '%s'\n",
 			blkdev->disk->disk_name);
 


### PR DESCRIPTION
* Subsequent to commit 1bf6a18
* This avoids race condition the driver would otherwise have if these
   groups were to be created with sysfs_add_groups().