### PR TITLE
kernel: sched: guard a DYNAMIC_STUNE_BOOST workqueue on boostgroup in…

### DIFF
--- a/kernel/sched/tune.c
+++ b/kernel/sched/tune.c
@@ -774,8 +774,9 @@ schedtune_boostgroup_init(struct schedtune *st, int idx)
 	/* Keep track of allocated boost groups */
 	allocated_group[idx] = st;
 	st->idx = idx;
-	
+#ifdef CONFIG_DYNAMIC_STUNE_BOOST	
 	INIT_WORK(&st->dsb_work, dsb_worker);
+#endif
 }
 
 static struct cgroup_subsys_state *


### PR DESCRIPTION
…itialization

this workqueue wasn't guarded properly on DYNAMIC_STUNE_BOOST Kconfig